### PR TITLE
Sets word-break for nav links

### DIFF
--- a/views/_head.jade
+++ b/views/_head.jade
@@ -19,7 +19,7 @@ style
   #nav > ul > li > ul > li > a {font-size:.9em}
   #nav > ul > li > ul {display: none;}
   #nav > ul > li.active > ul {display: block;}
-  #nav > ul > li > a {font-size: 1.1em;}
+  #nav > ul > li > a {font-size: 1.1em; word-break: break-word;}
   code {
     background: transparent;
     line-height: 1.3em;


### PR DESCRIPTION
For nav links that run long in Webkit, there can be an overlap:

![Overlap](https://photos-1.dropbox.com/t/0/AACL7lBzAulHN_mRZyiZHjeRb-C3wOc0K2UZDqUgZhrKxw/12/2428118/png/1024x768/3/1364094000/0/2/Screen%20Shot%202013-03-23%20at%206.11.23%20PM.png/w4SfX751qC6c9H1rrPFwZcJe_05pmLx_EzChGh8WNoQ).  

Firefox does not have this problem.  This patch adds a `word-break` rule to wrap the characters:

![Wrapped characters](https://photos-4.dropbox.com/t/0/AAC9DrYSky1YHHDrltO9kzJIRmVfawYlURhCpV6VPDrJLg/12/2428118/png/1024x768/3/1364094000/0/2/Screen%20Shot%202013-03-23%20at%206.12.16%20PM.png/GpPeCBzOP8cXsA_L3pwP91cJPLbTREtt4AfqMh3_MCw)

It's not super pretty, but it's an improvement.  If merged, please update grunt-dox as well to use the latest version of dox-foundation.
