### PR TITLE
BugFix: file separator should always be path.sep.

### DIFF
--- a/lib/dox-foundation.js
+++ b/lib/dox-foundation.js
@@ -46,9 +46,9 @@ function buildStructureForFile(file) {
   // How deep is your love?
   // If the splitted currentFile (the file we are currently rendering) path got one folder
   // in the path or more, add ../ for each level found
-  if(file.currentFile && file.currentFile.split('/').length > 1 ){
+  if(file.currentFile && file.currentFile.split(path.sep).length > 1 ){
     // Depth of current file
-    var depth = file.currentFile.split('/').length,
+    var depth = file.currentFile.split(path.sep).length,
     // Create a prefix with n "../"
     prefix = new Array(depth).join('../');
     // Set up target link with prefix
@@ -149,7 +149,7 @@ exports.createTargetFolders = function(target, files) {
   mkdirp.sync(target);
   
   files.forEach(function(file){
-    var folder = file.substr(0, file.lastIndexOf('/'));
+    var folder = file.substr(0, file.lastIndexOf(path.sep));
 
     if ((folder !== '') && (folders.indexOf(folder) === -1)) {
       folders.push(folder);


### PR DESCRIPTION
use "path.sep" instead of "/" so that it would work
Windows as well.
