### PR TITLE
Mention interactive demo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Outputted HTML is based on templates and css from [ZURB's Foundation](http://fou
 
 ## Example time!
 
+See <http://dox-foundation-demo.herokuapp.com/> ([source](https://github.com/tlvince/dox-foundation-demo)) for an interactive demo, ran against Express.
+
 ![A little sneak](http://i.cloudup.com/q9XWQ9B7qk.png)
 
 ## Installation


### PR DESCRIPTION
I've put together a [little demo](https://github.com/tlvince/dox-foundation-demo) to see how dox-foundation runs for real.

Note it highlights a couple of potential issues:
- An `overflow: ...` rule could be set on the TOC sections
- A base dir option (or equivalent) could be added to mitigate [redirects](https://github.com/tlvince/dox-foundation-demo/blob/master/server.js#L12-L14)
