### PR TITLE
Upgrade to Jade 1.0.0, to make dox-foundation usable again

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "underscore": "*",
     "dox": "~0.4.3",
     "commander": "~1.2.0",
-    "jade": "*",
+    "jade": "~1.0.0",
     "mkdirp": "*",
     "walkdir": "~0.0.7",
     "stylus": "~0.33.1"

--- a/views/_footer.jade
+++ b/views/_footer.jade
@@ -9,6 +9,8 @@ script(src='http://cdnjs.cloudflare.com/ajax/libs/foundation/4.1.6/js/foundation
 script(src='http://cdnjs.cloudflare.com/ajax/libs/foundation/4.1.6/js/foundation/foundation.reveal.min.js')
 
 // Prism js
-include js/prism.js
+script
+    include js/prism.js
 
-include js/page.js
+script
+    include js/page.js

--- a/views/_head.jade
+++ b/views/_head.jade
@@ -6,9 +6,11 @@ title= title
 link(rel="stylesheet", href="http://cdnjs.cloudflare.com/ajax/libs/foundation/4.1.6/css/foundation.min.css")
 
 // Prism CSS
-include css/prism.css
+style(type="text/css")
+    include css/prism.css
 
 // Custom Styles
-include css/dox-foundation.styl
+style(type="text/css")
+    include:styl css/dox-foundation.styl
 
 script(srr="http://cdnjs.cloudflare.com/ajax/libs/foundation/4.1.6/js/vendor/custom.modernizr.js")

--- a/views/template.jade
+++ b/views/template.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 html
   head
     include ./_head.jade


### PR DESCRIPTION
Dox-foundation as on NPM is currently unusable, as Jade's API has changed and there's no specific version specified here (see #48).

@acornejo's fix in #49 does solve that neatly as a short-term fix, but I'd much prefer it personally if dox-foundation just updated to the latest Jade release (1.0.0) properly, to make so this PR goes further and does that instead.

Essentially it's just an API change from `doctype 5` -> `doctype html`, and explicit wrapping of each `include` with the relevant tags to have it interpreted properly.
