### PR TITLE
fix: Use `doctype html` instead of `doctype 5`

### DIFF
--- a/views/template.jade
+++ b/views/template.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 html
   head
     include ./_head.jade


### PR DESCRIPTION
`doctype 5` is deprecated in favor of `doctype html`. Just installed a fresh version of `grunt-dox` and generation failed complaining of this doctype.
