### PR TITLE
Specified version for jade dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "underscore": "*",
     "dox": "~0.4.3",
     "commander": "~1.2.0",
-    "jade": "*",
+    "jade": "~0.35.0",
     "mkdirp": "*",
     "walkdir": "~0.0.7",
     "stylus": "~0.33.1"


### PR DESCRIPTION
The latest version of jade is causing a bunch of errors. It would probably be nice to update the jade templates so they are compatible with the latest version, but as a quick fix I just specified the version to `~0.35.0` in the package.json. Everything appears to be working correctly now.
