### PR TITLE
Making CDN Links relative to protcol.

### DIFF
--- a/views/_footer.jade
+++ b/views/_footer.jade
@@ -1,12 +1,12 @@
 // Foundation JS
-//- script(src='http://cdnjs.cloudflare.com/ajax/libs/foundation/3.2.2/javascripts/foundation.min.js')
+//- script(src='//cdnjs.cloudflare.com/ajax/libs/foundation/3.2.2/javascripts/foundation.min.js')
 script(type='text/javascript').
   document.write('<script src=' +
-  ('__proto__' in {} ? 'http://cdnjs.cloudflare.com/ajax/libs/zepto/1.0/zepto.min' : 'http://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min') +
+  ('__proto__' in {} ? '//cdnjs.cloudflare.com/ajax/libs/zepto/1.0/zepto.min' : '//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min') +
   '.js><\/script>')
 
-script(src='http://cdnjs.cloudflare.com/ajax/libs/foundation/4.1.6/js/foundation.min.js')
-script(src='http://cdnjs.cloudflare.com/ajax/libs/foundation/4.1.6/js/foundation/foundation.reveal.min.js')
+script(src='//cdnjs.cloudflare.com/ajax/libs/foundation/4.1.6/js/foundation.min.js')
+script(src='//cdnjs.cloudflare.com/ajax/libs/foundation/4.1.6/js/foundation/foundation.reveal.min.js')
 
 // Prism js
 script

--- a/views/_head.jade
+++ b/views/_head.jade
@@ -3,7 +3,7 @@ meta(name='viewport', content='width=device-width', charset='utf-8')
 title= title
 
 // Foundation CSS
-link(rel="stylesheet", href="http://cdnjs.cloudflare.com/ajax/libs/foundation/4.1.6/css/foundation.min.css")
+link(rel="stylesheet", href="//cdnjs.cloudflare.com/ajax/libs/foundation/4.1.6/css/foundation.min.css")
 
 // Prism CSS
 style(type="text/css")
@@ -13,4 +13,4 @@ style(type="text/css")
 style(type="text/css")
     include:styl css/dox-foundation.styl
 
-script(srr="http://cdnjs.cloudflare.com/ajax/libs/foundation/4.1.6/js/vendor/custom.modernizr.js")
+script(srr="//cdnjs.cloudflare.com/ajax/libs/foundation/4.1.6/js/vendor/custom.modernizr.js")


### PR DESCRIPTION
The documentation template does not work over 'https', because the resources from cloudflare are accessed vie 'http'.
This is a try to make these resources independent from used protocol.
